### PR TITLE
Update build target and build config to armhf

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 
 if [ "$1" == "build" ]
 then
-    snapcraft --destructive-mode --target-arch=arm64 --enable-experimental-target-arch
+    snapcraft --destructive-mode --target-arch=armhf --enable-experimental-target-arch
 
 elif [ "$1" == "clean" ]
 then

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,8 +8,8 @@ type: app
 base: core20
 
 architectures:
-  - build-on: [amd64, arm64]
-    run-on: arm64
+  - build-on: [amd64, arm64, armhf]
+    run-on: armhf
 
 confinement: strict
 grade: stable
@@ -59,7 +59,6 @@ parts:
             git clone https://github.com/OP-TEE/optee_client.git
             git clone https://github.com/OP-TEE/optee_test.git
             cp -r optee_* ${SNAPCRAFT_PART_SRC}/
-            pip3 install -U cryptography>=35.0.0
             rm -fr *
   
             for ver in {14..22}
@@ -76,18 +75,17 @@ parts:
             cat << EOF > build.sh
                 #! /bin/bash
                 export ARCH="arm"
-                export CROSS_COMPILE="${SNAPCRAFT_ARCH_TRIPLET}-"
-                export CROSS_COMPILE_core="${SNAPCRAFT_ARCH_TRIPLET}-"
-                export CROSS_COMPILE_ta_arm64="${SNAPCRAFT_ARCH_TRIPLET}-"
-                export CFG_USER_TA_TARGETS="ta_arm64"
-                export CFG_ARM64_core=y
+                export CROSS_COMPILE="arm-linux-gnueabihf-"
+                export CROSS_COMPILE_core="arm-linux-gnueabihf-"
+                export CROSS_COMPILE_ta_arm32="${SNAPCRAFT_ARCH_TRIPLET}-"
+                export CFG_USER_TA_TARGETS="ta_arm32"
                 export DEBUG=0 \
                 export CFG_TEE_CORE_LOG_LEVEL=1 \
                 export CFG_TEE_TA_LOG_LEVEL=1 \
                 export CFG_TEE_BENCHMARK=n
                 export CFG_CORE_HEAP_SIZE=262144
                 export PLATFORM=imx
-                export PLATFORM_FLAVOR=mx8mmevk
+                export PLATFORM_FLAVOR=mx6qsabreauto
                 export CFG_CORE_HUK_SUBKEY_COMPAT_USE_OTP_DIE_ID=n
       
                 make O=${SNAPCRAFT_PART_BUILD}/optee_os/out -j$(nproc)
@@ -105,7 +103,7 @@ parts:
   
             cat << EOF > build.sh
                 #! /bin/bash
-                export ARCH="arm64"
+                export ARCH="${SNAPCRAFT_ARCH_TRIPLET}"
                 export LDFLAGS="-Wl,--strip-all"
                 export DEBUG=0 \
                 export CROSS_COMPILE="${SNAPCRAFT_ARCH_TRIPLET}-"
@@ -141,8 +139,8 @@ parts:
                 export LIBDIR="/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}"
                 export SBINDIR="/usr/sbin"
                 export ARCH="${SNAPCRAFT_TARGET_ARCH}"
-                export CFG_USER_TA_TARGETS="ta_arm64"
-                export CROSS_COMPILE_ta_arm64="${SNAPCRAFT_ARCH_TRIPLET}-"
+                export CFG_USER_TA_TARGETS="ta_arm32"
+                export CROSS_COMPILE_ta_arm32="${SNAPCRAFT_ARCH_TRIPLET}-"
                 export O="${SNAPCRAFT_PART_BUILD}/optee_test/out"
                 export LDFLAGS="-L${SNAPCRAFT_PART_INSTALL}/${version}/usr/lib -L${SNAPCRAFT_PART_INSTALL}/${version}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}"
                 export CPPFLAGS=-isystem${SNAPCRAFT_PART_INSTALL}/${version}/usr/include
@@ -150,7 +148,7 @@ parts:
                 make -j$(nproc)
                 make install
                 mkdir -p ${SNAPCRAFT_PART_INSTALL}/${version}/unsigned_elf
-                find  ${SNAPCRAFT_PART_BUILD}/optee_test/out -name *stripped.elf -exec cp {} ${SNAPCRAFT_PART_INSTALL}/${version}/unsigned_elf \;
+                #find  ${SNAPCRAFT_PART_BUILD}/optee_test/out -name *stripped.elf -exec cp {} ${SNAPCRAFT_PART_INSTALL}/${version}/unsigned_elf \;
     
             EOF
                 chmod +x build.sh
@@ -209,21 +207,16 @@ build-packages:
     - build-essential
     - device-tree-compiler
     - flex
-    - gcc-aarch64-linux-gnu
-    - g++-aarch64-linux-gnu
-    - libxml2-dev
     - libssl-dev
-    - python3
-    - python3-crypto
-    - python3-pip
-    - python3-pyelftools
-    - python3-pycryptodome
     - wget
     - pkg-config
     - uuid-dev
     - zlib1g-dev
-    - to arm64:
-        - uuid-dev:arm64
+    - to armhf:
+        - binutils-arm-linux-gnueabi
+        - gcc-${SNAPCRAFT_ARCH_TRIPLET}
+        - g++-${SNAPCRAFT_ARCH_TRIPLET}
+        - uuid-dev:armhf
 plugs:
     xtest:
         interface: content


### PR DESCRIPTION
impact:
    snap/snapcraft.yaml

description:
    This branch is for armhf, so change build target to armhf
    ## Current limitation
        Not support for user to sign their own TA due to snapcraft clear execstack failed
        on ELF files, and snap store does not accept files withc execstack
test:
    N/A